### PR TITLE
Null island bug (support for 0,0 co-ordinates)

### DIFF
--- a/geojson.js
+++ b/geojson.js
@@ -122,15 +122,18 @@
         attr;
 
     for(var gtype in params.geom) {
-      attr = (typeof params.geom[gtype] === 'object') ? params.geom[gtype][0] : params.geom[gtype];
-      if(params.geom.hasOwnProperty(gtype) && item[attr]) {
-        geom.type = gtype;
+      var val = params.geom[gtype];
 
-        if(typeof params.geom[gtype] === 'string') {
-          geom.coordinates = item[params.geom[gtype]];
-        } else {
-          geom.coordinates = [item[params.geom[gtype][1]], item[params.geom[gtype][0]]];
-        }
+      // Geometry parameter specified as: {Point: 'coords'}
+      if(typeof val === 'string' && item.hasOwnProperty(val)) {
+        geom.type = gtype;
+        geom.coordinates = item[val];
+      }
+
+      // Geometry parameter specified as: {Point: ['lat', 'lng']}
+      else if(Array.isArray(val) && item.hasOwnProperty(val[0]) && item.hasOwnProperty(val[1])){
+        geom.type = gtype;
+        geom.coordinates = [item[val[1]], item[val[0]]];
       }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -286,6 +286,17 @@ describe('GeoJSON', function() {
       });
     });
 
+    it("returns valid GeoJSON output for 0,0", function(done){
+      GeoJSON.parse([{ lat: 0, lng: 0 }], {Point: ['lat', 'lng']}, function(geojson){
+        expect(geojson.type).to.be('FeatureCollection');
+        expect(geojson.features).to.be.an('array');
+        expect(geojson.features.length).to.be(1);
+        expect(geojson.features[0].geometry.coordinates[0]).to.equal(0);
+        expect(geojson.features[0].geometry.coordinates[1]).to.equal(0);
+        done();
+      });
+    });
+
     it("throws an error if no geometry attributes have been specified", function() {
       expect(function(){ GeoJSON.parse(data); }).to.throwException(/No geometry attributes specified/);
     });


### PR DESCRIPTION
support for 0,0 co-ordinates

```javascript
GeoJSON.parse([{ lat: 0, lng: 0 }], {Point: ['lat', 'lng']}, function(geojson){
  console.log( JSON.stringify( geojson, null, 2 ) );
});
```

before:
```javascript
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {},
      "properties": {}
    }
  ]
}
```

after:
```javascript
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          0,
          0
        ]
      },
      "properties": {}
    }
  ]
}
```