### PR TITLE
Extend parser to also accept geojson formatted objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ The valid geometry types are
 - `Polygon`
 - `MultiPolygon`
 
+To parse already encoded GeoJSON use
+  
+`GeoJSON`
+
+    var data = [{name: 'Location A', geo: {"type": "Point", "coordinates": [125.6, 10.1]}}];
+    
+    GeoJSON.parse(data, {GeoJSON: 'geo'});
+
+	"type": "FeatureCollection",
+	"features": [{
+		"type": "Feature",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [125.6, 10.1]
+		},
+		"properties": {
+			"name": "Location A"
+		}
+	}]
+}
+
 #### bbox, crs
 
 geojson.js also supports the optional GeoJSON properties `bbox` and `crs`.

--- a/geojson.js
+++ b/geojson.js
@@ -30,7 +30,7 @@
   };
 
   // Helper functions
-  var geoms = ['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon'],
+  var geoms = ['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon', 'GeoJSON'],
       geomAttrs = [];
 
   // Adds default settings to user-specified params
@@ -140,8 +140,12 @@
 
       // Geometry parameter specified as: {Point: 'coords'}
       if(typeof val === 'string' && item.hasOwnProperty(val)) {
-        geom.type = gtype;
-        geom.coordinates = item[val];
+        if(gtype === 'GeoJSON') {
+          geom = item[val]
+        } else {
+          geom.type = gtype;
+          geom.coordinates = item[val];
+        }
       }
 
       // Geometry parameter specified as: {Point: ['lat', 'lng']}

--- a/test/test.js
+++ b/test/test.js
@@ -370,5 +370,20 @@ describe('GeoJSON', function() {
 
       expect(function(){ GeoJSON.parse(data, options); }).to.not.throwException();
     });
+
+    it("accepts already formatted GeoJSON", function() {
+
+        var data = [{name: 'Location A', geo: {"type": "Point", "coordinates": [125.6, 10.1]}}];
+        var output = GeoJSON.parse(data, {GeoJSON: 'geo'});
+
+        expect(output.type).to.be('FeatureCollection');
+        expect(output.features).to.be.an('array');
+        expect(output.features.length).to.be(1);
+        expect(output.features[0].geometry.coordinates[0]).to.equal(125.6);
+        expect(output.features[0].geometry.coordinates[1]).to.equal(10.1);
+        expect(output.features[0].geometry.type).to.equal('Point');
+        expect(output.features[0].properties.name).to.equal('Location A');
+
+    });
   });
 });


### PR DESCRIPTION
Extend parser to also accept geojson formatted objects.

    var data = [{name: 'Location A', geo: {"type": "Point", "coordinates": [125.6, 10.1]}}];

    GeoJSON.parse(data, {GeoJSON: 'geo'});

produces

	"type": "FeatureCollection",
	"features": [{
		"type": "Feature",
		"geometry": {
			"type": "Point",
			"coordinates": [125.6, 10.1]
		},
		"properties": {
			"name": "Location A"
		}
	}]

Fixes  #14 