### PR TITLE
Remove engine warning during installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-lib-phantomjs": "~0.3.1"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">= 0.10"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
I have been using geojson with Node 4 without any issue. This change updates the engine field to suppress the warning displayed during installation:
```
npm install
[...]
npm WARN engine geojson@0.4.0: wanted: {"node":"0.10.x"} (current: {"node":"4.4.1","npm":"2.14.20"})
```